### PR TITLE
Auri: Release request (v0.9.0)

### DIFF
--- a/.changesets/5bopf.minor.md
+++ b/.changesets/5bopf.minor.md
@@ -1,1 +1,0 @@
-Breaking: Generate GitHub releases on publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `auri`
 
+## 0.9.0
+
+### Minor changes
+
+- Breaking: Generate GitHub releases on publish ([#73](https://github.com/pilcrowOnPaper/auri/pull/73))
+
 ## 0.8.1
 
 ### Patch changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "auri",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "auri",
-			"version": "0.8.0",
+			"version": "0.8.1",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "auri",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Organize package changes and releases",
 	"main": "/dist/index.js",
 	"types": "/dist/index.d.ts",


### PR DESCRIPTION
## Minor changes
- Breaking: Generate GitHub releases on publish ([#73](https://github.com/pilcrowOnPaper/auri/pull/73))
