### PR TITLE
Auri: Release request (v1.1.0)

### DIFF
--- a/.changesets/1714561596-37hw0.minor.md
+++ b/.changesets/1714561596-37hw0.minor.md
@@ -1,1 +1,0 @@
-Generate changeset ID with time info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # auri
 
+## 1.1.0
+
+### Minor changes
+
+- Generate changeset ID with time info ([#89](https://github.com/pilcrowOnPaper/auri/pull/89))
+
 ## 1.0.2
 
 ### Patch changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "auri",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "auri",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "auri",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "Organize package changes and releases",
 	"type": "module",
 	"files": [


### PR DESCRIPTION
## Minor changes
- Generate changeset ID with time info ([#89](https://github.com/pilcrowOnPaper/auri/pull/89))
