### PR TITLE
Auri: Release request (v2.0.0)

### DIFF
--- a/.changesets/1714574661-au0y0.major.md
+++ b/.changesets/1714574661-au0y0.major.md
@@ -1,1 +1,0 @@
-Breaking: Remove `auri patch next`

--- a/.changesets/1714574662-dplzn.major.md
+++ b/.changesets/1714574662-dplzn.major.md
@@ -1,1 +1,0 @@
-Breaking: Add `auri patch major`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # auri
 
-## 2.0.0-next.0
+## 2.0.0
 
 ## Major changes
 
-- Breaking: Remove `auri patch next`
-- Breaking: Add `auri patch major`
+- Breaking: Remove `auri patch next` ([#92](https://github.com/pilcrowOnPaper/auri/pull/92))
+- Breaking: Add `auri patch major` ([#92](https://github.com/pilcrowOnPaper/auri/pull/92))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "auri",
-	"version": "1.1.0",
+	"version": "2.0.0-next.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "auri",
-			"version": "1.1.0",
+			"version": "2.0.0-next.0",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "auri",
-	"version": "2.0.0-next.0",
+	"version": "2.0.0",
 	"description": "Organize package changes and releases",
 	"type": "module",
 	"files": [


### PR DESCRIPTION
## Major changes
- Breaking: Remove `auri patch next` ([#92](https://github.com/pilcrowOnPaper/auri/pull/92))
- Breaking: Add `auri patch major` ([#92](https://github.com/pilcrowOnPaper/auri/pull/92))
